### PR TITLE
add subenv.yml aliases handling

### DIFF
--- a/substance/command/aliases.py
+++ b/substance/command/aliases.py
@@ -1,5 +1,6 @@
 from substance.monads import *
 from substance.logs import *
+from substance.utils import mergeDictOverwrite
 from substance import (Engine, Command)
 from substance.exceptions import (SubstanceError)
 
@@ -21,12 +22,17 @@ class Aliases(Command):
 
     def main(self):
         return self.core.loadCurrentEngine(name=self.parent.getOption('engine')) \
+            .bind(Engine.envLoadCurrent) \
             .bind(Engine.loadConfigFile) \
+            .bind(Engine.loadSubenvConfigFile) \
             .bind(self.exportAliases) \
             .catch(self.exitError)
 
     def exportAliases(self, engine):
         aliases = engine.config.get('aliases')
+        if engine.subenvConfig.get('aliases'):
+            aliases = mergeDictOverwrite(engine.config.get('aliases'),
+                                         engine.subenvConfig.get('aliases'))
         if aliases:
             prefix = self.getOption('prefix')
             suffix = self.getOption('suffix')

--- a/substance/command/fallback.py
+++ b/substance/command/fallback.py
@@ -22,7 +22,9 @@ class Fallback(Command):
 
     def main(self):
         return self.core.loadCurrentEngine(name=self.parent.getOption('engine')) \
+            .bind(Engine.envLoadCurrent) \
             .bind(Engine.loadConfigFile) \
+            .bind(Engine.loadSubenvConfigFile) \
             .bind(Engine.envExecAlias, alias=self.name, args=self.args) \
             .catch(self.onEngineException)
 

--- a/substance/utils.py
+++ b/substance/utils.py
@@ -195,6 +195,13 @@ def mergeDict(a, b, path=None):
     return a
 
 
+# merge 2 dicts and overwrite target keys with source keys if collision
+def mergeDictOverwrite(target, source):
+    merged = target.copy()
+    merged.update(source)
+    return merged
+
+
 def readDotEnv(filepath, env={}):
     with open(filepath) as f:
         return parseDotEnv(f, env)


### PR DESCRIPTION
let me know if you want some tests with this.
```
The `subenv.yml` is a useful file for storing subenv specific
settings that you might need for your project. one common use case
for this file would be to integrate custom aliases specific to your
project. However, this feature wasn't supported.

These changes now make it possible to add an aliases section to
your `subenv.yml` the same way as you would in your default
`engine.yml`.

This is done by navigating to the specific sub-envs path and
loading up the `subenv.yml` inside the engine and merging
both aliases sections when aliases are accessed.
```
Fixes #22 