### PR TITLE
Make unison-fsmonitor use python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Local Docker-powered development environments
 
-# Overview
+## Overview
 
-## Why?
+### Why?
 Substance combines a virtual machine and docker into one self contained tool.
 Complex projects can be distributed with a .substance folder which defines all
 the environmental details in one so you can spend more time developing and less
 time setting up servers.
 
-## How
+### How
 Substance is backed by Virtual Box, the docker engine and ``dockwrkr`` to
 compose containers. With substance you create an `engine` which runs it's own
 virtual machine with the docker daemon and synchronizes a `devroot` folder with
@@ -18,6 +18,10 @@ your project source code to the engine. Substance then allows you to switch
 from project to project simply by having a simple `.substance` folder in the
 root of your project source to define the containers and folders/volumes needed
 to run your project.
+
+## Requirements
+
+* Python 3.x
 
 ## Documentation
 

--- a/support/unison/macos-10.12/unison-fsmonitor
+++ b/support/unison/macos-10.12/unison-fsmonitor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # unox
 #


### PR DESCRIPTION
If `#!/usr/bin/env python` is python2 and `fsevents` is not installed for that version, `substance sync` will exit with an error. Avoid the issue by explicitly calling python3 in `unison-fsmonitor.py`

Update README to note the dependency on python3. Fixes #48 