### PR TITLE
Installation instructions for Linux

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,6 +5,9 @@ Substance supports all three main desktop operating systems: macOS, Windows,
 and Linux. Its main prerequisite is `Oracle VirtualBox`_, which also supports
 these platforms.
 
+If an existing substance project is going to be used, make sure to check how much
+RAM and disk space will be required before procceding with the installation.
+
 On macOS
 --------
 
@@ -154,6 +157,25 @@ Substance has been tested on Mint, Ubuntu, and Arch Linux.
 #. Install ``substance``::
 
      $ sudo pip install substance
+
+Ubuntu 20.04 LTS
+^^^^^^^^^^^^^^^^
+
+This version of Ubuntu already comes with the development libraries required for
+substance.
+
+#. Install `Oracle VirtualBox`_.
+
+#. Substance requires Python 3 and pip 3. Python 3 will be already installed and
+   it is accessible with ``python3``. Install pip 3 with::
+
+     $ sudo apt install pip3
+
+#. Install ``substance``::
+
+     $ sudo pip3 install substance
+
+Make sure you use Python 3 and pip 3, and not the Python 2 counterpart.
 
 Upgrading Substance to a new version
 ------------------------------------


### PR DESCRIPTION
I did the installation of substance for Ubuntu 20.04 LTS and I ran into some issues.

- I didn't have enough space for the substance project I was going to install.
- The instructions say Python 2 is required but substance only works with Python 3 and its pip counterpart.
- In the VirtualBox installation, I checked if the `VBoxManage` variable was in the `PATH`, but it was not. Everything worked ok so I don't know if this is really required. Maybe in other Linux versions.
- I didn't have to install any of the Linux packages listed. (I did the installation of Ubuntu with the recommended libraries.)

So I updated some details about the installation instructions.

1. Before any step is followed, if an existing project is going to be used, make sure the user check how much RAM and disk space will be required.
2. Added specific instructions for Linux Ubuntu 20.04 LTS.

**You can see the [installation document preview](https://github.com/romelperez/substance/blob/docs/installation/docs/source/installation.rst).**

Let me know if these instructions will also be applicable for other Linux distributions or if anything else should be updated.